### PR TITLE
Update Litestar version to v2.8.2

### DIFF
--- a/.github/workflows/update-toast.yml
+++ b/.github/workflows/update-toast.yml
@@ -28,7 +28,7 @@ jobs:
     - name: Update conf.py
       if: steps.latest_release.outputs.version != env.CURRENT_VERSION
       env:
-        CURRENT_VERSION: v2.8.2
+        CURRENT_VERSION: v2.8.2v2.8.2
       run: |
         sed -i "s/Litestar $CURRENT_VERSION/Litestar ${{ steps.latest_release.outputs.version }}/g" conf.py
         sed -i "s|/release-notes/changelog.html#$CURRENT_VERSION|/release-notes/changelog.html#${{ steps.latest_release.outputs.version }}|g" conf.py
@@ -36,7 +36,7 @@ jobs:
     - name: Update workflow file
       if: steps.latest_release.outputs.version != env.CURRENT_VERSION
       run: |
-        sed -i "s/CURRENT_VERSION: $CURRENT_VERSION/CURRENT_VERSION: ${{ steps.latest_release.outputs.version }}/g" .github/workflows/update-toast.yml
+        sed -i "s/CURRENT_VERSION: v2.8.2$CURRENT_VERSION/CURRENT_VERSION: v2.8.2${{ steps.latest_release.outputs.version }}/g" .github/workflows/update-toast.yml
 
     - name: Create pull request
       if: steps.latest_release.outputs.version != env.CURRENT_VERSION


### PR DESCRIPTION
A new Litestar release (v2.8.2) has been detected.
This PR updates the version in the `conf.py` file and the `CURRENT_VERSION` in the workflow file.