### PR TITLE
Update Litestar version to 2.8.2

### DIFF
--- a/page/conf.py
+++ b/page/conf.py
@@ -190,9 +190,9 @@ html_context = {
         },
     ],
     "announcement": {
-        "title": "Litestar 2.6 has just been released!",
+        "title": "Litestar 2.8.2 has just been released!",
         "description": "Check it out here",
-        "link": "https://docs.litestar.dev/2/release-notes/changelog.html#2.6.0",
+        "link": "https://docs.litestar.dev/latest/release-notes/changelog.html#2.8.2",
     },
     "project_name": "Litestar",
     "project_url": "https://litestar.dev",


### PR DESCRIPTION
A new Litestar release (2.8.2) has been detected.
This PR updates the version in the `docs/conf.py` file and the `CURRENT_VERSION` in the workflow file.