### PR TITLE
Update Litestar version to 2.9.0

### DIFF
--- a/page/conf.py
+++ b/page/conf.py
@@ -190,7 +190,7 @@ html_context = {
         },
     ],
     "announcement": {
-        "title": "Litestar 2.8.3 has just been released!",
+        "title": "Litestar 2.9.0 has just been released!",
         "description": "Check it out here",
         "link": "https://docs.litestar.dev/latest/release-notes/changelog.html#2.8.2",
     },


### PR DESCRIPTION
A new Litestar release (2.9.0) has been detected.
This PR updates the version in the `docs/conf.py` file and the `CURRENT_VERSION` in the workflow file.