### PR TITLE
fix: broken openapi links

### DIFF
--- a/page/conf.py
+++ b/page/conf.py
@@ -118,14 +118,14 @@ html_context = {
                 "Automatically generated OpenAPI schemas help to document APIs and integrate with the frontend via "
                 "TypeScript schema generation"
             ),
-            "link": "https://docs.litestar.dev/2/usage/openapi.html",
+            "link": "https://docs.litestar.dev/2/usage/openapi/index.html",
         },
         {
             "title": "Interactive API Documentation",
             "content": (
                 "Interactively explore your APIs through Swagger, Redoc or Stoplight Elements, powered by OpenAPI"
             ),
-            "link": "https://docs.litestar.dev/2/usage/openapi.html",
+            "link": "https://docs.litestar.dev/2/usage/openapi/ui_plugins.html",
         },
         {
             "title": "Middlewares",


### PR DESCRIPTION
<!--
By submitting this pull request, you agree to:
- follow [Litestar's Code of Conduct](https://github.com/litestar-org/.github/blob/main/CODE_OF_CONDUCT.md)
- follow [Litestar's contribution guidelines](https://github.com/litestar-org/.github/blob/main/CONTRIBUTING.md)
- follow the [PSFs's Code of Conduct](https://www.python.org/psf/conduct/)
-->
## Description

Just noticed there are two broken links on the front page, wasn't too sure about the second but I assume that is where it is supposed to point to.

<!--
Please add in issue numbers this pull request will close, if applicable
Examples: Fixes #4321 or Closes #1234

Ensure you are using a supported keyword to properly link an issue:
https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->

