### PR TITLE
Update Litestar version to 2.11.0

### DIFF
--- a/.github/workflows/update-toast.yml
+++ b/.github/workflows/update-toast.yml
@@ -28,7 +28,7 @@ jobs:
     - name: Update docs/conf.py
       if: steps.latest_release.outputs.version != env.CURRENT_VERSION
       env:
-        CURRENT_VERSION: 2.10.0
+        CURRENT_VERSION: 2.11.0
       run: |
         sed -Ei "s/(\"title\": \"Litestar )[[:digit:].]*( has just been released!\")/\1${{ steps.latest_release.outputs.version }}\2/" page/conf.py
         sed -Ei "s|(https://docs.litestar.dev/latest/release-notes/changelog.html#)[[:digit:].]*|\1${{ steps.latest_release.outputs.version }}|" page/conf.py

--- a/page/conf.py
+++ b/page/conf.py
@@ -190,9 +190,9 @@ html_context = {
         },
     ],
     "announcement": {
-        "title": "Litestar 2.10.0 has just been released!",
+        "title": "Litestar 2.11.0 has just been released!",
         "description": "Check it out here",
-        "link": "https://docs.litestar.dev/latest/release-notes/changelog.html#2.10.0",
+        "link": "https://docs.litestar.dev/latest/release-notes/changelog.html#2.11.0",
     },
     "project_name": "Litestar",
     "project_url": "https://litestar.dev",


### PR DESCRIPTION
A new Litestar release (2.11.0) has been detected.
This PR updates the version in the `page/conf.py` file and the `CURRENT_VERSION` in the workflow file.