### PR TITLE
Update Litestar version to 2.12.1

### DIFF
--- a/.github/workflows/update-toast.yml
+++ b/.github/workflows/update-toast.yml
@@ -28,7 +28,7 @@ jobs:
     - name: Update docs/conf.py
       if: steps.latest_release.outputs.version != env.CURRENT_VERSION
       env:
-        CURRENT_VERSION: 2.11.0
+        CURRENT_VERSION: 2.12.1
       run: |
         sed -Ei "s/(\"title\": \"Litestar )[[:digit:].]*( has just been released!\")/\1${{ steps.latest_release.outputs.version }}\2/" page/conf.py
         sed -Ei "s|(https://docs.litestar.dev/latest/release-notes/changelog.html#)[[:digit:].]*|\1${{ steps.latest_release.outputs.version }}|" page/conf.py


### PR DESCRIPTION
A new Litestar release (2.12.1) has been detected.
This PR updates the version in the `page/conf.py` file and the `CURRENT_VERSION` in the workflow file.